### PR TITLE
Add gnused

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -9,6 +9,9 @@
       "gnumake": {
         "pkg-path": "gnumake"
       },
+      "gnused": {
+        "pkg-path": "gnused"
+      },
       "python3": {
         "pkg-path": "python3"
       }
@@ -56,6 +59,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T01:11:25.028943Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -88,6 +92,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T01:28:03.808202Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -120,6 +125,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T01:43:36.123070Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -152,6 +158,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T02:01:52.747850Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -184,6 +191,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T01:11:25.160303Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -216,6 +224,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T01:28:04.274163Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -249,6 +258,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T01:43:36.286158Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -281,6 +291,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T02:01:53.276004Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -294,6 +305,130 @@
         "info": "/nix/store/33lvx5blf6ms1b6ynaln49hx1xksypxf-gnumake-4.4.1-info",
         "man": "/nix/store/y87b22iwv64wrfpgyii4gjgbhcfqq0mi-gnumake-4.4.1-man",
         "out": "/nix/store/k0hhyz6qnj5065vpw15m4r7nbs0mn706-gnumake-4.4.1"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gnused",
+      "broken": false,
+      "derivation": "/nix/store/3cfx073blxpclkp0jwwv0d7y70ialr59-gnused-4.9.drv",
+      "description": "GNU sed, a batch stream editor",
+      "install_id": "gnused",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=2631b0b7abcea6e640ce31cd78ea58910d31e650",
+      "name": "gnused-4.9",
+      "pname": "gnused",
+      "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+      "rev_count": 782401,
+      "rev_date": "2025-04-12T13:19:24Z",
+      "scrape_date": "2025-04-14T01:11:25.164690Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "4.9",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/xcw6cljkzgpw1nlkkymwhbcy41027wgs-gnused-4.9-info",
+        "out": "/nix/store/pj9bj4cczgxwzgvgzjlgz5kzifwsh4ky-gnused-4.9"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gnused",
+      "broken": false,
+      "derivation": "/nix/store/d6i5ypjbrwdkjrvf4a8kc4ayhbsjzrqy-gnused-4.9.drv",
+      "description": "GNU sed, a batch stream editor",
+      "install_id": "gnused",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=2631b0b7abcea6e640ce31cd78ea58910d31e650",
+      "name": "gnused-4.9",
+      "pname": "gnused",
+      "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+      "rev_count": 782401,
+      "rev_date": "2025-04-12T13:19:24Z",
+      "scrape_date": "2025-04-14T01:28:04.280852Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "4.9",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/cfncvncp131kmshlplgblzj2ijba4yqp-gnused-4.9-info",
+        "out": "/nix/store/4c59cgm460f3sjk7964vf50lm22cvs1y-gnused-4.9"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gnused",
+      "broken": false,
+      "derivation": "/nix/store/vaxpb2c4rbxji6ksxgkrpw3nz0g13m8k-gnused-4.9.drv",
+      "description": "GNU sed, a batch stream editor",
+      "install_id": "gnused",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=2631b0b7abcea6e640ce31cd78ea58910d31e650",
+      "name": "gnused-4.9",
+      "pname": "gnused",
+      "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+      "rev_count": 782401,
+      "rev_date": "2025-04-12T13:19:24Z",
+      "scrape_date": "2025-04-14T01:43:36.290674Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "4.9",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/8zxvffw63rad9a8k9fld9da87yg6si43-gnused-4.9-info",
+        "out": "/nix/store/2nxnpw56r9kwlipqh4slr513wxgzg35b-gnused-4.9"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gnused",
+      "broken": false,
+      "derivation": "/nix/store/pbj06z1dx3jc9fkgnqh4v84gkvdxak4b-gnused-4.9.drv",
+      "description": "GNU sed, a batch stream editor",
+      "install_id": "gnused",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=2631b0b7abcea6e640ce31cd78ea58910d31e650",
+      "name": "gnused-4.9",
+      "pname": "gnused",
+      "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+      "rev_count": 782401,
+      "rev_date": "2025-04-12T13:19:24Z",
+      "scrape_date": "2025-04-14T02:01:53.283126Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "4.9",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/pcdrsxc6qy2nphlmhagbmbj4h55x18c1-gnused-4.9-info",
+        "out": "/nix/store/xhql0ilzbiqwnmz4z8y0phk611wynxf2-gnused-4.9"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -314,6 +449,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T01:11:33.513306Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -343,6 +479,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T01:28:24.422267Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -373,6 +510,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T01:43:44.797204Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -402,6 +540,7 @@
       "rev_date": "2025-04-12T13:19:24Z",
       "scrape_date": "2025-04-14T02:02:16.073720Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -5,6 +5,7 @@ version = 1
 gcc.pkg-path = "gcc11"
 gnumake.pkg-path = "gnumake"
 python3.pkg-path = "python3"
+gnused.pkg-path = "gnused"
 
 [options]
 systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]


### PR DESCRIPTION
The build script depends on gnused so it should be installed. Without it building headlines on macOS fails with:
```
sed: 1: "/tmp/store_c6651e7dee53 ...": unterminated substitute pattern
```